### PR TITLE
[STYLE] 게시판, 팟, 홈, 다른 유저 프로필 페이지에 반응형 적용

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,8 @@
 {
-    "arrowParens": "always", 
-    "jsxSingleQuote": false, 
-    "printWidth": 80,
-    "singleQuote": false, 
-    "tabWidth": 2
+  "arrowParens": "always",
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2
 }

--- a/src/app/(with-main-header)/MobileHeader.tsx
+++ b/src/app/(with-main-header)/MobileHeader.tsx
@@ -68,14 +68,14 @@ export default function MobileHeader() {
         <aside
           className={twMerge(
             "fixed -top-15 left-0 w-65 h-screen px-6 mt-15 bg-site-button backdrop:blur-lg transition-transform duration-200 ease-out z-50",
-            isOpen ? "translate-x-0" : "-translate-x-full"
+            isOpen ? "translate-x-0" : "-translate-x-full",
           )}
         >
           <button onClick={closeSidebar} className="absolute top-3 right-2.5">
             <Icon MuiIcon={CloseRoundedIcon} />
           </button>
 
-          <div className="flex flex-col gap-10 mt-27 font-bold">
+          <div className="flex flex-col gap-10 mt-27 font-semibold">
             <Link onClick={closeSidebar} href={"/signin"}>
               로그인
             </Link>
@@ -86,7 +86,7 @@ export default function MobileHeader() {
                     key={path}
                     className={twMerge(
                       "flex items-center w-full h-15 rounded-full",
-                      currentPathname === path && "bg-white"
+                      currentPathname === path && "bg-white",
                     )}
                   >
                     <Link

--- a/src/app/(with-main-header)/RankingCard.tsx
+++ b/src/app/(with-main-header)/RankingCard.tsx
@@ -1,7 +1,7 @@
-import Image from "next/image";
-import AvatarImg from "@/assets/images/avatar.png";
 import { twMerge } from "tailwind-merge";
 import Link from "next/link";
+import Character from "@/components/common/Character";
+import basic from "@/assets/images/costumes/basic.png";
 
 interface RankingCardProps {
   rank: number;
@@ -20,25 +20,21 @@ export default function RankingCard({
     <Link href="/users/1">
       <article
         className={twMerge(
-          "flex flex-col justify-end items-center gap-4 relative w-52.5 h-68 p-4 bg-site-button border-5 border-white rounded-[10px] transition-all",
+          "flex flex-col justify-end items-center gap-3 lg:gap-4 relative w-32 lg:w-52.5 h-41 lg:h-68 p-2 pt-4 lg:p-4 bg-site-button border-5 border-white rounded-[10px] transition-all",
           className,
         )}
       >
-        <div className="flex justify-center items-center absolute top-2 left-2 w-16 h-16 bg-site-bg rounded-full">
-          <span className="font-bitbitv2 text-2xl text-site-darkgray-02">
+        <div className="flex justify-center items-center absolute top-1 lg:top-2 left-1 lg:left-2 w-10 lg:w-16 h-10 lg:h-16 bg-site-bg rounded-full">
+          <span className="font-bitbitv2 text-base lg:text-2xl text-site-darkgray-02">
             {rank}등
           </span>
         </div>
-        <div className="flex justify-center w-34 h-34 rounded-full bg-site-profile">
-          <Image
-            className="scale-75 object-contain"
-            src={AvatarImg}
-            alt="내 아바타 이미지"
-          />
+        <div className="flex justify-center items-center w-20 lg:w-34 h-20 lg:h-34 rounded-full bg-site-profile">
+          <Character className="scale-90 -translate-y-2" costumeSrc={basic} />
         </div>
-        <div className="flex flex-col gap-2 items-center w-full h-17 font-galmuri bg-site-profile">
-          <p className="text-xl">{nickname}</p>
-          <p className="text-site-darkgray-01 text-sm">{time}</p>
+        <div className="flex flex-col gap-0 lg:gap-2 items-center w-full h-17 font-galmuri bg-site-profile">
+          <p className="font-normal lg:text-xl">{nickname}</p>
+          <p className="text-site-darkgray-01 text-xs lg:text-sm">{time}</p>
         </div>
       </article>
     </Link>

--- a/src/app/(with-main-header)/boards/BoardsHeader.tsx
+++ b/src/app/(with-main-header)/boards/BoardsHeader.tsx
@@ -17,9 +17,9 @@ export default function BoardsHeader() {
   };
 
   return (
-    <form onSubmit={search} className="flex flex-col gap-7">
-      <div className="flex justify-between">
-        <p className="font-galmuri text-[28px]">전체</p>
+    <form onSubmit={search} className="flex flex-col gap-4 lg:gap-7">
+      <div className="flex items-center justify-between">
+        <p className="font-galmuri text-xl lg:text-[28px]">전체</p>
         <Link href={"boards/create"}>
           <Button type="button">글쓰기</Button>
         </Link>

--- a/src/app/(with-main-header)/boards/PostImage.tsx
+++ b/src/app/(with-main-header)/boards/PostImage.tsx
@@ -9,7 +9,7 @@ export default function PostImage() {
   return (
     <div
       onClick={() => console.log("큰 화면으로 보기")}
-      className="w-40 h-40 bg-site-white-100 relative cursor-pointer"
+      className="w-25 lg:w-40 h-25 lg:h-40 bg-site-white-100 relative cursor-pointer"
     >
       <Image
         src={AvatarImg}
@@ -23,7 +23,7 @@ export default function PostImage() {
           e.stopPropagation();
           console.log("이미지 삭제");
         }}
-        className="absolute top-1 right-1 flex justify-center items-center w-7 h-7 bg-site-black-50 rounded-sm"
+        className="absolute top-0.5 lg:top-1 right-0.5 lg:right-1 flex justify-center items-center w-6 lg:w-7 h-6 lg:h-7 bg-site-black-50 rounded-sm"
       >
         <Icon MuiIcon={CloseRoundedIcon} className="text-white" />
       </button>

--- a/src/app/(with-main-header)/boards/PostItem.tsx
+++ b/src/app/(with-main-header)/boards/PostItem.tsx
@@ -6,8 +6,8 @@ import formatDateToTimeAgo from "../../../utils/formatDateToTimeAgo";
 export default function PostItem() {
   return (
     <Link href="/boards/1">
-      <article className="flex justify-between items-center h-40 p-2.5 bg-site-white-70">
-        <div className="flex flex-col gap-2.5 px-5">
+      <article className="flex justify-between items-center h-24 lg:h-40 pt-4 p-2.5 bg-site-white-70">
+        <div className="flex flex-col gap-1 lg:px-5">
           <p className="font-semibold line-clamp-1">진짜 공부하기 싫다</p>
           <p className="text-site-darkgray-02 line-clamp-1">
             오늘은 진짜 공부하기 싫은 날이네요...
@@ -16,7 +16,11 @@ export default function PostItem() {
             {formatDateToTimeAgo(new Date())}
           </p>
         </div>
-        <Image src={Logo} alt="STUV 로고 이미지" className="w-35 h-35" />
+        <Image
+          src={Logo}
+          alt="STUV 로고 이미지"
+          className="w-20 h-20 lg:w-35 lg:h-35"
+        />
       </article>
     </Link>
   );

--- a/src/app/(with-main-header)/boards/[id]/Comment.tsx
+++ b/src/app/(with-main-header)/boards/[id]/Comment.tsx
@@ -4,15 +4,15 @@ import basic from "@/assets/images/costumes/basic.png";
 
 export default function Comment() {
   return (
-    <article className="flex gap-2.5 items-center">
+    <article className="flex gap-2.5">
       <Link href="/users/1">
-        <Avatar costumeSrc={basic} className="w-14 h-14" />
+        <Avatar costumeSrc={basic} className="w-11 lg:w-14 h-11 lg:h-14" />
       </Link>
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col lg:gap-1">
         <Link href="/users/1" className="w-fit">
-          <p className="font-semibold text-xl ">@binnie</p>
+          <p className="font-semibold lg:text-xl">@binnie</p>
         </Link>
-        <p className="text-site-darkgray-02">
+        <p className="text-site-darkgray-02 text-sm lg:text-base">
           아 저도 오늘 진짜 공부 하기가 싫더라구요 주말이라 그런가... 주말에도
           공부하는 습관을 들여야하는데...
         </p>

--- a/src/app/(with-main-header)/boards/[id]/Comments.tsx
+++ b/src/app/(with-main-header)/boards/[id]/Comments.tsx
@@ -4,30 +4,33 @@ import InputIcon from "@/components/common/InputIcon";
 import ChatRoundedIcon from "@mui/icons-material/ChatRounded";
 import SendRoundedIcon from "@mui/icons-material/SendRounded";
 import Comment from "./Comment";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
+import Icon from "../../../../components/common/Icon";
 
 export default function Comments() {
   const [comment, setComment] = useState("");
+
+  const sendComment = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("댓글 작성");
+  };
   return (
-    <>
-      <div className="flex items-center gap-2.5">
-        <ChatRoundedIcon className="text-site-darkgray-02" />
-        <span className="text-xl text-site-darkgray-02">2</span>
+    <form onSubmit={sendComment}>
+      <div className="flex items-center gap-2.5 mt-5 mb-2.5 lg:my-7">
+        <Icon MuiIcon={ChatRoundedIcon} />
+        <span className="lg:text-xl text-site-darkgray-02">2</span>
       </div>
       <InputIcon
         value={comment}
         onChange={(e) => setComment(e.target.value)}
         placeholder="댓글을 남겨보세요"
         Icon={SendRoundedIcon}
-        onClickIcon={() => {
-          console.log("댓글 작성");
-        }}
       />
-      <div className="flex flex-col gap-7">
+      <div className="flex flex-col gap-8 lg:gap-7 mt-5 lg:mt-7">
         {[1, 2, 3].map((_, idx) => (
           <Comment key={idx} />
         ))}
       </div>
-    </>
+    </form>
   );
 }

--- a/src/app/(with-main-header)/boards/[id]/Post.tsx
+++ b/src/app/(with-main-header)/boards/[id]/Post.tsx
@@ -7,7 +7,7 @@ export default function Post() {
   return (
     <>
       <div className="border-b border-site-darkgray-02">
-        <h1 className="flex items-center h-20 px-8 font-semibold text-xl">
+        <h1 className="flex items-center h-12.5 lg:h-20 px-5 lg:px-8 font-semibold lg:text-xl">
           [자유] 진짜 공부하기 싫다
         </h1>
       </div>
@@ -27,7 +27,7 @@ export default function Post() {
           <PostDeleteButton />
         </p>
       </div>
-      <div className="min-h-[200px] bg-site-white-70 px-6 py-5">
+      <div className="min-h-[200px] bg-site-white-70 p-5 lg:px-6">
         오늘은 진짜 공부 하기 싫은 날이네요...
       </div>
     </>

--- a/src/app/(with-main-header)/boards/[id]/page.tsx
+++ b/src/app/(with-main-header)/boards/[id]/page.tsx
@@ -10,7 +10,7 @@ export default async function BoardDetail({ params }: BoardDetailProps) {
   const { id } = await params;
 
   return (
-    <section className="flex flex-col gap-5">
+    <section className="flex flex-col gap-2.5 lg:gap-5 px-5 lg:px-0">
       <Post />
       <div className="flex gap-2.5 items-center">
         {[1, 2].map((_, idx) => (

--- a/src/app/(with-main-header)/boards/[id]/update/page.tsx
+++ b/src/app/(with-main-header)/boards/[id]/update/page.tsx
@@ -5,29 +5,41 @@ import Icon from "@/components/common/Icon";
 import AddPhotoAlternateRoundedIcon from "@mui/icons-material/AddPhotoAlternateRounded";
 import PostImage from "../../PostImage";
 import Input from "@/components/common/Input";
+import { FormEvent, useState } from "react";
 
 export default function BoardsUpdate() {
+  const [title, setTitle] = useState("");
+
+  const updatePost = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("게시글 수정");
+  };
+
   return (
-    <div className="flex flex-col gap-6">
+    <form onSubmit={updatePost} className="flex flex-col gap-6 mx-5 lg:mx-0">
       <div className="flex justify-between items-center">
         <Button disabled>자유</Button>
-        <Button onClick={() => console.log("수정 완료")}>수정하기</Button>
+        <Button>수정하기</Button>
       </div>
       <div className="border-b border-site-darkgray-02">
         <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
           className="bg-transparent"
           placeholder="게시글 제목을 입력해주세요"
+          required
         />
       </div>
       <textarea
-        className="min-h-50 bg-site-white-70 px-6 py-5 resize-none"
+        className="min-h-50 bg-site-white-70 px-5 lg:px-6 py-5 resize-none"
         spellCheck="false"
         placeholder="본문 내용을 입력해주세요"
+        required
       />
       <div className="flex gap-2.5 items-center">
         <label
           htmlFor="board-images"
-          className="flex justify-center items-center w-40 h-40 bg-site-lightgray cursor-pointer"
+          className="flex justify-center items-center w-25 lg:w-40 h-25 lg:h-40 bg-site-lightgray cursor-pointer"
         >
           <input id="board-images" type="file" className="hidden" />
           <Icon MuiIcon={AddPhotoAlternateRoundedIcon} />
@@ -36,6 +48,6 @@ export default function BoardsUpdate() {
           <PostImage key={idx} />
         ))}
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/app/(with-main-header)/boards/create/page.tsx
+++ b/src/app/(with-main-header)/boards/create/page.tsx
@@ -6,38 +6,44 @@ import Button from "@/components/common/Button";
 import AddPhotoAlternateRoundedIcon from "@mui/icons-material/AddPhotoAlternateRounded";
 import Input from "@/components/common/Input";
 import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 
 export default function BoardsCreate() {
   const [title, setTitle] = useState("");
 
+  const createPost = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("게시글 작성");
+  };
+
   return (
-    <form className="flex flex-col gap-6">
+    <form onSubmit={createPost} className="flex flex-col gap-6 px-5 lg:px-0">
       <div className="flex justify-between items-center">
-        <Button type="button" className="w-34 justify-start">
-          <span className="ml-10">자유</span>
+        <Button type="button">
+          <span className="ml-2.5">자유</span>
           <Icon MuiIcon={ArrowDropDownRoundedIcon} />
         </Button>
-        <Button onClick={() => console.log("작성 완료")}>작성하기</Button>
+        <Button>작성하기</Button>
       </div>
       <div className="border-b border-site-darkgray-02">
         <Input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          required
           className="bg-transparent"
           placeholder="게시글 제목을 입력해주세요"
+          required
         />
       </div>
       <textarea
-        className="min-h-50 bg-site-white-70 px-6 py-5 resize-none"
+        className="min-h-50 bg-site-white-70 px-5 lg:px-6 py-5 resize-none"
         spellCheck="false"
         placeholder="본문 내용을 입력해주세요"
+        required
       />
       <div className="flex gap-2.5 items-center">
         <label
           htmlFor="board-images"
-          className="flex justify-center items-center w-40 h-40 bg-site-lightgray cursor-pointer"
+          className="flex justify-center items-center w-25 lg:w-40 h-25 lg:h-40 bg-site-lightgray cursor-pointer"
         >
           <input id="board-images" type="file" className="hidden" />
           <Icon MuiIcon={AddPhotoAlternateRoundedIcon} />

--- a/src/app/(with-main-header)/boards/page.tsx
+++ b/src/app/(with-main-header)/boards/page.tsx
@@ -3,9 +3,9 @@ import BoardsHeader from "./BoardsHeader";
 
 export default function Boards() {
   return (
-    <div className="flex flex-col gap-13">
+    <div className="flex flex-col gap-10 lg:gap-13 px-5 lg:px-0">
       <BoardsHeader />
-      <section className="flex flex-col gap-5">
+      <section className="flex flex-col gap-2 lg:gap-5">
         {[1, 2, 3].map((_, idx) => (
           <PostItem key={idx} />
         ))}

--- a/src/app/(with-main-header)/layout.tsx
+++ b/src/app/(with-main-header)/layout.tsx
@@ -7,7 +7,7 @@ export default function layout({ children }: { children: ReactNode }) {
     <Noise>
       <div className="w-full min-h-screen h-screen bg-site-bg overflow-x-hidden">
         <Header />
-        <main className="px-0 lg:px-12 pb-13 pt-30 lg:pt-40">{children}</main>
+        <main className="px-0 lg:px-12 pb-13 pt-22.5 lg:pt-40">{children}</main>
       </div>
     </Noise>
   );

--- a/src/app/(with-main-header)/page.tsx
+++ b/src/app/(with-main-header)/page.tsx
@@ -7,7 +7,7 @@ import OngoingParties from "./party/OngoingParties";
 export default function Home() {
   return (
     <>
-      <section className="flex flex-col justify-center items-center gap-24">
+      <section className="flex flex-col justify-center items-center gap-10 lg:gap-24">
         <Image
           className="w-67 h-10"
           src={weekRanking}
@@ -18,23 +18,23 @@ export default function Home() {
             rank={2}
             nickname={"@stuv_2nd"}
             time={"46:49:00"}
-            className="translate-x-10 -rotate-6 drop-shadow-50 hover:scale-105"
+            className="translate-x-10 drop-shadow-50 -rotate-6 hover:rotate-0 hover:scale-120 hover:z-30"
           />
           <RankingCard
             rank={1}
             nickname={"@stuv_1st"}
             time={"46:49:00"}
-            className="-rotate-14 z-10 scale-110 drop-shadow-6.2 hover:scale-115"
+            className="scale-110 drop-shadow-6.2 -rotate-14 hover:rotate-0 hover:scale-120 z-10 hover:z-30"
           />
           <RankingCard
             rank={3}
             nickname={"@stuv_3rd"}
             time={"46:49:00"}
-            className="-translate-x-10 rotate-6 drop-shadow-50 hover:scale-105"
+            className="-translate-x-10 drop-shadow-50 rotate-6 hover:rotate-0 hover:scale-120 hover:z-30"
           />
         </div>
       </section>
-      <div className="flex flex-col gap-13 mt-24">
+      <div className="flex flex-col gap-13 mt-10 lg:mt-24">
         <EventParties />
         <OngoingParties />
       </div>

--- a/src/app/(with-main-header)/party/ClosedParties.tsx
+++ b/src/app/(with-main-header)/party/ClosedParties.tsx
@@ -2,15 +2,15 @@ import Button from "../../../components/common/Button";
 export default function ClosedParties() {
   return (
     <section className="flex flex-col gap-7 mt-15">
-      <p className="font-galmuri text-2xl">
+      <p className="font-galmuri text-xl lg:text-2xl px-5 lg:px-0">
         <span>마감된 팟</span>
         <span className="ml-3">3</span>
       </p>
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2.5 lg:gap-3">
         {[1, 2, 3].map((_, index) => (
           <article
             key={index}
-            className="flex justify-between items-center h-25 bg-site-button px-5"
+            className="flex justify-between items-center h-14 lg:h-25 bg-site-button px-5"
           >
             <div className="flex gap-2.5 items-end">
               <p className="font-semibold text-xl">팟 이름</p>

--- a/src/app/(with-main-header)/party/EventParties.tsx
+++ b/src/app/(with-main-header)/party/EventParties.tsx
@@ -8,8 +8,8 @@ import Link from "next/link";
 
 export default function EventParties() {
   return (
-    <section className="flex flex-col gap-7 mt-15">
-      <p className="font-galmuri text-2xl">
+    <section className="flex flex-col gap-2.5 lg:gap-7 mt-15 px-5 lg:px-0">
+      <p className="font-galmuri text-xl lg:text-2xl">
         <span>진행 중인 이벤트 팟</span>
         <span className="ml-3">4</span>
       </p>
@@ -19,7 +19,7 @@ export default function EventParties() {
           0: {
             slidesPerView: 1,
             spaceBetween: 0,
-            pagination: true,
+            pagination: { clickable: true },
           },
           768: {
             slidesPerView: 3.3,

--- a/src/app/(with-main-header)/party/OngoingParties.tsx
+++ b/src/app/(with-main-header)/party/OngoingParties.tsx
@@ -4,17 +4,20 @@ import PartyItem from "./PartyItem";
 export default function OngoingParties() {
   return (
     <section className="flex flex-col gap-7 mt-15">
-      <div className="flex justify-between items-center">
-        <p className="font-galmuri text-2xl">
+      <div className="flex justify-between items-end px-5 lg:px-0">
+        <p className="font-galmuri text-xl lg:text-2xl">
           <span>참여 중인 팟</span>
           <span className="ml-3">6</span>
         </p>
-        <Link href={"/party/all"} className="text-xl text-site-darkgray-01">
+        <Link
+          href={"/party/all"}
+          className="text-base lg:text-xl text-site-darkgray-01"
+        >
           전체보기
         </Link>
       </div>
       <div className="flex flex-col gap-3">
-        <div className="flex items-center font-semibold text-xl">
+        <div className="flex items-center font-semibold lg:text-xl px-5 lg:px-7">
           <p className="flex-5">팟</p>
           <p className="flex-2">인원</p>
           <p className="flex-3">시작일</p>

--- a/src/app/(with-main-header)/party/OngoingParties.tsx
+++ b/src/app/(with-main-header)/party/OngoingParties.tsx
@@ -3,7 +3,7 @@ import PartyItem from "./PartyItem";
 
 export default function OngoingParties() {
   return (
-    <section className="flex flex-col gap-7 mt-15">
+    <section className="flex flex-col gap-7 lg:mt-15">
       <div className="flex justify-between items-end px-5 lg:px-0">
         <p className="font-galmuri text-xl lg:text-2xl">
           <span>참여 중인 팟</span>

--- a/src/app/(with-main-header)/party/PartyItem.tsx
+++ b/src/app/(with-main-header)/party/PartyItem.tsx
@@ -5,9 +5,9 @@ export default function PartyItem() {
   return (
     <Link
       href={"/party/1"}
-      className="flex items-center font-semibold text-xl h-25 px-7 bg-site-button"
+      className="flex items-center font-semibold lg:text-xl h-25 px-5 lg:px-7 bg-site-button"
     >
-      <p className="flex-5">오하요-기상인증🔥</p>
+      <p className="flex-5 line-clamp-1">오하요-기상인증🔥</p>
       <p className="flex-2">99/100</p>
       <p className="flex-3">{formatDateToKR(new Date())}</p>
     </Link>

--- a/src/app/(with-main-header)/party/UpcomingParties.tsx
+++ b/src/app/(with-main-header)/party/UpcomingParties.tsx
@@ -4,17 +4,20 @@ import PartyItem from "./PartyItem";
 export default function UpcomingParties() {
   return (
     <section className="flex flex-col gap-7 mt-15">
-      <div className="flex justify-between items-center">
-        <p className="font-galmuri text-2xl">
+      <div className="flex justify-between items-end px-5 lg:px-0">
+        <p className="font-galmuri text-xl lg:text-2xl">
           <span>시작 전인 팟</span>
           <span className="ml-3">6</span>
         </p>
-        <Link href={"/party/all"} className="text-xl text-site-darkgray-01">
+        <Link
+          href={"/party/all"}
+          className="text-base lg:text-xl text-site-darkgray-01"
+        >
           전체보기
         </Link>
       </div>
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center font-semibold text-xl">
+      <div className="flex flex-col gap-2.5 lg:gap-3">
+        <div className="flex items-center font-semibold lg:text-xl px-5 lg:px-7">
           <p className="flex-5">팟</p>
           <p className="flex-2">인원</p>
           <p className="flex-3">시작일</p>

--- a/src/app/(with-main-header)/party/[id]/ParticipateButton.tsx
+++ b/src/app/(with-main-header)/party/[id]/ParticipateButton.tsx
@@ -26,7 +26,7 @@ export default function ParticipateButton() {
   };
   return (
     <>
-      <div className="flex justify-end h-15">
+      <div className="flex justify-end">
         <Button onClick={() => open("participate-party")}>참여하기</Button>
       </div>
 

--- a/src/app/(with-main-header)/party/[id]/page.tsx
+++ b/src/app/(with-main-header)/party/[id]/page.tsx
@@ -15,12 +15,12 @@ export default async function PartyDetail({ params }: PartyDetailProps) {
 
   return (
     <>
-      <div className="flex flex-col gap-13">
+      <div className="flex flex-col gap-7.5 lg:gap-13 px-5 lg:px-0">
         <ParticipateButton />
-        <div className="flex items-center w-full h-20 border-b border-site-darkgray-02">
+        <div className="flex items-center w-full h-12.5 lg:h-20 border-b border-site-darkgray-02">
           <Input
             value={"한 입크기로 잘라먹는 Next.js"}
-            className="w-full bg-transparent"
+            className="w-full bg-transparent font-semibold"
             disabled
           />
         </div>
@@ -28,50 +28,57 @@ export default async function PartyDetail({ params }: PartyDetailProps) {
           인프런 한 입 크기로 잘라먹는 Next.js 매일매일 강의 하나씩 들을 팟
           구합니다!
         </p>
-        <div className="flex items-center gap-13">
+        <div className="flex flex-col lg:flex-row gap-7.5 lg:gap-13">
           <div className="flex items-center gap-5">
-            <label htmlFor="max-people" className="font-semibold text-xl">
+            <label
+              htmlFor="max-people"
+              className="min-w-fit font-semibold lg:text-xl"
+            >
               인원
             </label>
             <Button
-              className="justify-start px-6 w-80 text-base font-pretendard bg-site-white-70"
+              className="justify-start px-4 lg:px-6 w-80 text-sm lg:text-base font-pretendard bg-site-white-70"
               disabled
             >
               1 / 20
             </Button>
           </div>
 
-          <div className="flex items-center gap-13">
-            <div className="flex items-center gap-5">
-              <label htmlFor="date" className="font-semibold text-xl">
-                기간
-              </label>
-              <div className="flex items-center gap-1">
-                <Button
-                  className="w-fit gap-4 px-6 text-base font-pretendard bg-site-white-70"
-                  disabled
-                >
-                  <span>{formatDateToKR(new Date())}</span>
-                  <Icon MuiIcon={CalendarMonthRoundedIcon} />
-                </Button>
-                <span>-</span>
-                <Button
-                  className="w-fit gap-4 px-6 text-base font-pretendard bg-site-white-70"
-                  disabled
-                >
-                  <span>{formatDateToKR(new Date())}</span>
-                  <Icon MuiIcon={CalendarMonthRoundedIcon} />
-                </Button>
-              </div>
+          <div className="flex items-center gap-5">
+            <label
+              htmlFor="date"
+              className="min-w-fit font-semibold lg:text-xl"
+            >
+              기간
+            </label>
+            <div className="flex items-center min-w-fit gap-1">
+              <Button
+                className="gap-4 px-4 lg:px-6 text-sm lg:text-base font-pretendard bg-site-white-70"
+                disabled
+              >
+                <span>{formatDateToKR(new Date())}</span>
+                <Icon MuiIcon={CalendarMonthRoundedIcon} />
+              </Button>
+              <span>-</span>
+              <Button
+                className="gap-4 px-4 lg:px-6 text-sm lg:text-base font-pretendard bg-site-white-70"
+                disabled
+              >
+                <span>{formatDateToKR(new Date())}</span>
+                <Icon MuiIcon={CalendarMonthRoundedIcon} />
+              </Button>
             </div>
           </div>
 
           <div className="flex items-center gap-5">
-            <label htmlFor="min-betting" className="font-semibold text-xl">
+            <label
+              htmlFor="min-betting"
+              className="min-w-fit font-semibold lg:text-xl"
+            >
               배팅
             </label>
             <Button
-              className="justify-start px-6 w-80 text-base font-pretendard bg-site-white-70"
+              className="justify-start px-4 lg:px-6 w-80 text-sm lg:text-base font-pretendard bg-site-white-70"
               disabled
             >
               최소 100 포인트부터
@@ -81,7 +88,7 @@ export default async function PartyDetail({ params }: PartyDetailProps) {
       </div>
 
       {/* 참여자 목록 (참여 후에만 보임) */}
-      <section className="flex flex-col gap-8 mt-13">
+      <section className="flex flex-col gap-8 mt-13 px-5 lg:px-0">
         <p className="font-semibold text-xl">참여자 목록</p>
         <div className="flex flex-col gap-6">
           {[1, 2, 3, 4].map((_, index) => (

--- a/src/app/(with-main-header)/party/all/page.tsx
+++ b/src/app/(with-main-header)/party/all/page.tsx
@@ -5,27 +5,33 @@ import Button from "../../../../components/common/Button";
 import InputIcon from "@/components/common/InputIcon";
 import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
 import PartyItem from "../PartyItem";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 
 export default function PartyAll() {
   const [keyword, setKeyword] = useState("");
+
+  const search = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("팟 검색");
+  };
   return (
-    <div className="flex flex-col">
-      <div className="flex justify-between items-center mb-7">
-        <p className="font-galmuri text-[28px]">전체</p>
-        <Link href={"/party/create"}>
-          <Button>팟 생성</Button>
-        </Link>
+    <form onSubmit={search} className="flex flex-col">
+      <div className="px-5 lg:px-0">
+        <div className="flex justify-between items-center mb-5 lg:mb-7">
+          <p className="font-galmuri text-xl lg:text-[28px]">전체</p>
+          <Link href={"/party/create"}>
+            <Button type="button">팟 생성</Button>
+          </Link>
+        </div>
+        <InputIcon
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          Icon={SearchRoundedIcon}
+          className="mb-7.5 lg:mb-13"
+        />
       </div>
-      <InputIcon
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        Icon={SearchRoundedIcon}
-        onClickIcon={() => console.log("검색")}
-        className="mb-13"
-      />
       <div className="flex flex-col gap-3">
-        <div className="flex items-center font-semibold text-xl">
+        <div className="flex items-center font-semibold lg:text-xl px-5 lg:px-7">
           <p className="flex-5">팟</p>
           <p className="flex-2">인원</p>
           <p className="flex-3">시작일</p>
@@ -34,6 +40,6 @@ export default function PartyAll() {
           <PartyItem key={index} />
         ))}
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/app/(with-main-header)/party/create/page.tsx
+++ b/src/app/(with-main-header)/party/create/page.tsx
@@ -20,11 +20,11 @@ export default function PartyCreate() {
     setEndDate(new Date(newEndDate));
   }, [startDate]);
   return (
-    <form className="flex flex-col gap-13">
-      <div className="flex justify-end h-15">
+    <form className="flex flex-col gap-7.5 lg:gap-13">
+      <div className="flex justify-end">
         <CreatePartyButton />
       </div>
-      <div className="flex items-center h-20 border-b border-site-darkgray-02">
+      <div className="flex items-center h-12.5 lg:h-20 border-b border-site-darkgray-02">
         <Input
           type="text"
           value={title}
@@ -38,11 +38,11 @@ export default function PartyCreate() {
         className="min-h-50 bg-site-white-70 px-6 py-5 resize-none"
         spellCheck="false"
         placeholder={`팟 인원 수, 수행 퀘스트 등 팟에 대해 설명해주세요!
-  *인증 방식은 무조건 이미지 업로드를 통해서만 가능합니다`}
+*인증 방식은 무조건 이미지 업로드를 통해서만 가능합니다`}
       />
-      <div className="flex items-center gap-13">
+      <div className="flex flex-col lg:flex-row items-center gap-7.5 lg:gap-13">
         <div className="flex items-center gap-5">
-          <label htmlFor="max-people" className="font-semibold text-xl">
+          <label htmlFor="max-people" className="font-semibold lg:text-xl">
             인원
           </label>
           <Input
@@ -60,7 +60,7 @@ export default function PartyCreate() {
 
         <div className="flex items-center gap-13">
           <div className="flex items-center gap-5">
-            <label htmlFor="date" className="font-semibold text-xl">
+            <label htmlFor="date" className="font-semibold lg:text-xl">
               기간
             </label>
             <div className="flex items-center gap-1">
@@ -80,7 +80,7 @@ export default function PartyCreate() {
         </div>
 
         <div className="flex items-center gap-5">
-          <label htmlFor="min-betting" className="font-semibold text-xl">
+          <label htmlFor="min-betting" className="font-semibold lg:text-xl">
             배팅
           </label>
           <Input

--- a/src/app/(with-main-header)/party/page.tsx
+++ b/src/app/(with-main-header)/party/page.tsx
@@ -6,7 +6,7 @@ import UpcomingParties from "./UpcomingParties";
 export default function Party() {
   return (
     <div className="flex flex-col relative">
-      <div className="fixed top-25 left-0 w-screen h-15 bg-site-button flex justify-between items-center px-12 z-10">
+      <div className="fixed top-15 lg:top-25 left-0 w-screen h-15 bg-site-button flex justify-between items-center px-12 z-10">
         <p className="font-semibold">[일일미션] 공부 시간 3시간 이상</p>
         <p className="font-semibold">진행중</p>
       </div>

--- a/src/app/(with-main-header)/users/[id]/PostsByUser.tsx
+++ b/src/app/(with-main-header)/users/[id]/PostsByUser.tsx
@@ -2,7 +2,7 @@ import PostItem from "../../boards/PostItem";
 
 export default function PostsByUser() {
   return (
-    <section className="flex flex-col gap-8">
+    <section className="flex flex-col gap-2 lg:gap-8">
       <p className="flex gap-1.5 font-semibold">
         <span>게시글</span>
         <span>6</span>

--- a/src/app/(with-main-header)/users/[id]/StudyTimeJandy.tsx
+++ b/src/app/(with-main-header)/users/[id]/StudyTimeJandy.tsx
@@ -10,7 +10,7 @@ export default function StudyTimeJandy() {
   ).getDate();
 
   return (
-    <section className="flex flex-col gap-8">
+    <section className="flex flex-col gap-2 lg:gap-8">
       <div className="flex justify-between items-center">
         <p className="font-semibold">공부 시간</p>
         <div className="flex items-center gap-4">
@@ -23,7 +23,7 @@ export default function StudyTimeJandy() {
           </button>
         </div>
       </div>
-      <div className="grid grid-cols-7 auto-cols-auto gap-2">
+      <div className="grid grid-cols-7 auto-cols-auto gap-1 lg:gap-2">
         {Array.from({ length: daysOfMonth }).map((_, index) => (
           <div
             key={`day${index + 1}`}

--- a/src/app/(with-main-header)/users/[id]/UserProfile.tsx
+++ b/src/app/(with-main-header)/users/[id]/UserProfile.tsx
@@ -7,13 +7,15 @@ import Link from "next/link";
 
 export default function UserProfile() {
   return (
-    <section className="flex flex-col min-w-92 gap-7">
-      <p className="font-bitbitv2 text-[28px]">@binnie</p>
-      <div className="flex gap-13">
-        <Avatar costumeSrc={basic} className="w-40 h-40" />
-        <div className="flex flex-col justify-end items-center gap-7.5">
-          <p className="font-galmuri text-2xl">
-            <Link href={"/friends/1"} className="mr-3">친구</Link>
+    <section className="flex flex-col min-w-full lg:min-w-92 gap-2.5 lg:gap-7 px-2.5">
+      <p className="font-bitbitv2 text-2xl lg:text-[28px]">@binnie</p>
+      <div className="flex items-center lg:items-end gap-13">
+        <Avatar costumeSrc={basic} className="w-32.5 lg:w-40 h-32.5 lg:h-40" />
+        <div className="flex flex-col justify-end items-center gap-6 lg:gap-7.5">
+          <p className="font-galmuri text-xl lg:text-2xl">
+            <Link href={"/friends/1"} className="mr-3">
+              친구
+            </Link>
             <span className="text-site-darkgray-02">16</span>
           </p>
           <Button>친구신청</Button>

--- a/src/app/(with-main-header)/users/[id]/page.tsx
+++ b/src/app/(with-main-header)/users/[id]/page.tsx
@@ -1,18 +1,22 @@
+"use client";
+
 import StudyTimeJandy from "./StudyTimeJandy";
 import PostsByUser from "./PostsByUser";
 import UserProfile from "./UserProfile";
+import { useParams } from "next/navigation";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import Image from "next/image";
+import WhiteDividerShort from "@/assets/images/WhiteDividerShort.svg";
 
-interface UserProfileProps {
-  params: Promise<{ id: string }>;
-}
-
-export default async function UserDetail({ params }: UserProfileProps) {
-  const { id } = await params;
+export default function UserDetail() {
+  const { id } = useParams();
+  const isMobile = useIsMobile();
 
   return (
-    <div className="flex justify-center gap-20 px-8">
+    <div className="flex flex-col lg:flex-row lg:justify-center items-center lg:items-start gap-12.5 lg:gap-20 px-5 lg:px-8">
       <UserProfile />
-      <section className="flex flex-col w-206 gap-13">
+      {isMobile && <Image src={WhiteDividerShort} alt="구분선 이미지" />}
+      <section className="flex flex-col w-full lg:w-206 gap-7.5 lg:gap-13">
         <StudyTimeJandy />
         <PostsByUser />
       </section>

--- a/src/assets/css/globals.css
+++ b/src/assets/css/globals.css
@@ -49,6 +49,19 @@
   background-color: #3a75bb;
 }
 
+/* SWIPER */
+.swiper-pagination-bullet {
+  width: 12px !important;
+  height: 12px !important;
+  border: 2px solid white !important;
+  background-color: transparent !important;
+  opacity: 1 !important;
+}
+
+.swiper-pagination-bullet-active {
+  background-color: white !important;
+}
+
 input,
 textarea,
 button {

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -11,6 +11,11 @@ interface IconProps {
 
 export default function Icon({ MuiIcon, className }: IconProps) {
   return (
-    <MuiIcon className={twMerge("lg:!w-7 lg:!h-7 text-[#1C1B1F]", className)} />
+    <MuiIcon
+      className={twMerge(
+        "!w-6 lg:!w-7 !h-6 lg:!h-7 text-site-darkgray-02",
+        className,
+      )}
+    />
   );
 }

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -27,7 +27,7 @@ export default function Input({
       value={value}
       onChange={onChange}
       className={twMerge(
-        "flex justify-center items-center w-full h-11 lg:h-15 bg-site-white-70 px-6 rounded-full text-base lg:text-xl",
+        "flex justify-center items-center w-full h-11 lg:h-15 bg-site-white-70 px-5 lg:px-6 rounded-full text-base lg:text-xl",
         className,
       )}
       {...props}

--- a/src/components/common/InputIcon.tsx
+++ b/src/components/common/InputIcon.tsx
@@ -33,7 +33,7 @@ export default function InputIcon({
       />
       <button
         onClick={onClickIcon}
-        className="absolute top-1/2 -translate-y-1/2 right-7 text-site-darkgray-02"
+        className="absolute top-1/2 -translate-y-1/2 right-4 lg:right-7 text-site-darkgray-02"
       >
         <Icon MuiIcon={MuiIcon} />
       </button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,23 +1,22 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent <hover:text-accent></hover:text-accent>-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
@@ -31,27 +30,27 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Button.displayName = "Button"
+    );
+  },
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/datePicker.tsx
+++ b/src/components/ui/datePicker.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
 import * as React from "react";
@@ -34,7 +33,7 @@ export function DatePicker({
         <Button
           variant={"outline"}
           className={cn(
-            "w-44 h-15 justify-between px-6 font-pretendard font-normal text-base rounded-full",
+            "w-38 lg:w-44 h-11 lg:h-15 justify-between px-4 lg:px-6 font-pretendard font-normal text-base rounded-full bg-site-white-70",
             !value && "text-muted-foreground",
           )}
         >


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->

## ✨ 반영 브랜치

`style/apply-mobile-ui` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->

## 📝 설명

<!-- 상세 task 변경사항 체크리스트로 기술 -->

## ✅ 변경 사항

- [x] `Icon`, `Input`, `InputIcon`, `datePicker` 공통 컴포넌트에 반응형 적용
- [x] 모바일 레이아웃에서의 py값 수정
- [x] 모바일 헤더 폰트 굵기 bold -> semibold로 변경
- [x] swiper 페이지네이션 버튼 커스텀
- [x] 게시판 페이지 반응형 적용
- [x] 팟 페이지 반응형 적용
- [x] 홈 (로그인 전) 반응형 적용
- [x] 다른 유저 프로필 페이지 반응형 적용

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->

## 💬 PR 포인트 & 질문사항


## 📷 변경사항 스크린샷

<!-- 필수는 아니지만, 변경사항을 사진으로 공유하시면 좋아요! -->

- 변화된 부분을 올려주시면 좋아요 ✔

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->

## 📢 이슈 정보

#9 
