### PR TITLE
[FIX] 유저 친구 목록 페이지 패딩 수정 및 인증 버튼 비활성화 버그 수정

### DIFF
--- a/src/app/(with-main-header)/friends/[id]/page.tsx
+++ b/src/app/(with-main-header)/friends/[id]/page.tsx
@@ -11,7 +11,7 @@ export default async function UserFriends({ params }: UserFriendsProps) {
 
   if (!friends) return;
   return (
-    <section className="flex flex-col w-full gap-5 lg:gap-8">
+    <section className="flex flex-col w-full gap-5 lg:gap-8 px-5 lg:px-8">
       <p className="flex items-center gap-2.5 font-galmuri text-xl lg:text-2xl">
         <span>친구</span>
         <span>{friends.data.length}</span>

--- a/src/app/(with-main-header)/friends/add/FriendRequestButton.tsx
+++ b/src/app/(with-main-header)/friends/add/FriendRequestButton.tsx
@@ -40,7 +40,7 @@ export default function FriendRequestButton({
   };
   return isRequestFriend ? (
     <Button onClick={deleteFriend}>
-      {status === "FRIEND" ? "삭제" : "요청취소"}
+      {status === "FRIEND" || status === "ACCEPTED" ? "삭제" : "요청취소"}
     </Button>
   ) : (
     <Button onClick={requestFriend}>친구요청</Button>

--- a/src/app/(with-main-header)/party/[id]/AfterParticipateButtons.tsx
+++ b/src/app/(with-main-header)/party/[id]/AfterParticipateButtons.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { partyApi } from "@/api/party/party";
-import { revalidatePathAction } from "@/actions";
 import Button from "@/components/common/Button";
 import Icon from "@/components/common/Icon";
 import Modal from "@/components/common/Modal";
@@ -95,7 +94,7 @@ export default function AfterParticipateButtons({
     <>
       <Button onClick={participateChatting}>채팅</Button>
       <Button
-        disabled={today < start}
+        disabled={start < today}
         onClick={() => open(`verify-participate`)}
       >
         인증


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->

## ✨ 반영 브랜치

`fix/user-profile-padding` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->

## 📝 설명

<!-- 상세 task 변경사항 체크리스트로 기술 -->

## ✅ 변경 사항

- [x] 유저 친구 목록 페이지 - 페이지 반응형 수정
- [x] 파티 - 진행 중인 팟에서 인증 버튼이 비활성화 되는 버그 수정
- [x] 유저 프로필 - 이미 친구인 유저인 경우에, 요청 취소 버튼이 보이던 버그 수정

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->

## 💬 PR 포인트 & 질문사항

- PR 좀 봐주세요~~
- 어떻게 생각하시나요?

## 📷 변경사항 스크린샷

<!-- 필수는 아니지만, 변경사항을 사진으로 공유하시면 좋아요! -->

![image](https://github.com/user-attachments/assets/5d6d092e-c0c0-4904-95a1-f0255d73c9e8)

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->

## 📢 이슈 정보

#174 
