### PR TITLE
[FEAT] 로그인 및 회원가입 성공 토스트 추가 + 기타 버그 수정 

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -66,12 +66,11 @@ const signUp = async (body: signUpReq) => {
   }
 };
 
-const signIn = async ({ isAutoLogin, ...body }: signInReq) => {
+const signIn = async ({ ...body }: signInReq) => {
   try {
     await deleteCookie("accessToken");
     const response = await fetchCustom.post(`/user/login`, {
       headers: {
-        // "X-Remember-Me": isAutoLogin ? "true" : "false",
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),

--- a/src/api/auth/auth.type.ts
+++ b/src/api/auth/auth.type.ts
@@ -21,5 +21,4 @@ interface signUpReq {
 interface signInReq {
   email: string;
   password: string;
-  isAutoLogin: boolean;
 }

--- a/src/app/(with-auth-header)/signin/page.tsx
+++ b/src/app/(with-auth-header)/signin/page.tsx
@@ -7,11 +7,10 @@ import Divider from "@/assets/images/BlueDividerLong.svg";
 import KakaoButton from "@/assets/images/kakaoLoginButton.png";
 import KakaoMobileButton from "@/assets/images/MobilekakaoLoginButton.png";
 
-import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import Button from "@/components/common/Button";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import useInputValidation from "@/hooks/useInputValidation";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect } from "react";
 import InputWithErrorMsg from "@/components/common/InputWithErrorMsg";
 import { authApi } from "@/api/auth/auth";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -26,7 +25,6 @@ export default function SignIn() {
   const searchParams = useSearchParams();
   const code = searchParams.get("code");
 
-  const [isAutoLogin, setIsAutoLogin] = useState(false);
   const { validate: emailValidate, ...email } = useInputValidation(
     "",
     (email) => {
@@ -53,7 +51,6 @@ export default function SignIn() {
       const res = await authApi.signIn({
         email: email.value,
         password: password.value,
-        isAutoLogin,
       });
       if (res?.status === "성공") {
         if (res.data.role === "관리자") {

--- a/src/app/(with-auth-header)/signin/page.tsx
+++ b/src/app/(with-auth-header)/signin/page.tsx
@@ -54,8 +54,10 @@ export default function SignIn() {
       });
       if (res?.status === "성공") {
         if (res.data.role === "관리자") {
+          showToast("관리자로 로그인에 성공했습니다");
           router.replace("/admin");
         } else {
+          showToast("로그인에 성공했습니다");
           router.replace("/");
         }
       } else {

--- a/src/app/(with-auth-header)/signin/page.tsx
+++ b/src/app/(with-auth-header)/signin/page.tsx
@@ -72,12 +72,13 @@ export default function SignIn() {
         await deleteCookie("accessToken");
         await deleteCookieAtServer("accessToken");
         await authApi.kakaoLogin(code);
+        showToast("로그인에 성공했습니다");
         router.replace("/");
       }
     };
 
     kakaoLogin();
-  }, [code, router]);
+  }, [code, router, showToast]);
 
   return (
     <div className="w-full lg:w-150 flex flex-col gap-7 mx-auto mt-[52px] mb-7">

--- a/src/app/(with-auth-header)/signup/page.tsx
+++ b/src/app/(with-auth-header)/signup/page.tsx
@@ -8,9 +8,11 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { debounce } from "@mui/material";
 import Input from "@/components/common/Input";
+import { useToastStore } from "@/store/toastStore";
 
 export default function Signup() {
   const router = useRouter();
+  const { showToast } = useToastStore();
 
   const [isVerifiedNickname, setIsVerifiedNickname] = useState(false);
   const [isVerifiedEmail, setIsVerifiedEmail] = useState(false);
@@ -71,10 +73,10 @@ export default function Signup() {
       nickname: nickname.value,
     });
     if (res?.status === "성공") {
-      alert("사용 가능한 닉네임입니다");
+      showToast("사용 가능한 닉네임입니다");
       setIsVerifiedNickname(true);
     } else {
-      alert("이미 사용중인 닉네임입니다");
+      showToast("이미 사용중인 닉네임입니다");
       setIsVerifiedNickname(false);
     }
   };
@@ -87,8 +89,11 @@ export default function Signup() {
 
     const res = await authApi.sendVerificationEmail({ email: email.value });
     if (res?.status === "성공") {
-      alert("인증 메일을 발송했습니다");
+      showToast("인증 메일을 발송했습니다");
       setIsSentVerificationEmail(true);
+    } else {
+      showToast("인증 메일 발송에 실패했습니다");
+      setIsSentVerificationEmail(false);
     }
   };
 
@@ -100,10 +105,10 @@ export default function Signup() {
       code: verificationCode,
     });
     if (res?.status === "성공") {
-      alert("이메일 인증이 완료되었습니다");
+      showToast("이메일 인증이 완료되었습니다");
       setIsVerifiedEmail(true);
     } else {
-      alert("인증번호가 일치하지 않습니다");
+      showToast("인증번호가 일치하지 않습니다");
       setIsVerifiedEmail(false);
     }
   };
@@ -124,6 +129,7 @@ export default function Signup() {
       });
 
       if (res?.status === "성공") {
+        showToast("회원가입이 완료되었습니다");
         router.push("/signin");
       }
     }

--- a/src/app/(with-main-header)/RankingCard.tsx
+++ b/src/app/(with-main-header)/RankingCard.tsx
@@ -36,7 +36,7 @@ export default async function RankingCard({
           <Character className="scale-90 -translate-y-2" costumeSrc={profile} />
         </div>
         <div className="flex flex-col gap-0 lg:gap-2 items-center w-full h-17 font-galmuri bg-site-profile">
-          <p className="font-normal lg:text-xl line-clamp-1">{nickname}</p>
+          <p className="font-normal lg:text-xl line-clamp-1">@{nickname}</p>
           <p className="text-site-darkgray-01 text-xs lg:text-sm">{time}</p>
         </div>
       </article>

--- a/src/app/(with-main-header)/UserCard.tsx
+++ b/src/app/(with-main-header)/UserCard.tsx
@@ -18,7 +18,7 @@ export default async function UserCard() {
         </div>
         <div className="flex flex-col max-w-47.5 lg:max-w-55.5 gap-2.5 lg:gap-5 font-galmuri text-xl lg:text-2xl">
           <div className="font-bitbitv2 text-2xl lg:text-[28px]">
-            {user.data.nickname}
+            @{user.data.nickname}
           </div>
           <div className="flex gap-2">
             <div>공부 시간</div>

--- a/src/app/(with-main-header)/chatting/ChattingListItem.tsx
+++ b/src/app/(with-main-header)/chatting/ChattingListItem.tsx
@@ -24,11 +24,9 @@ export default function ChattingListItem({
   unreadCount,
   userInfo,
   groupInfo,
-  lastUserInfo,
   createdAt,
 }: ChattingListItemProps) {
   const isPrivateChat = roomType === "PRIVATE";
-  const nickname = isPrivateChat ? userInfo?.nickname : groupInfo?.groupName;
 
   const modifiedCreatedAt = createdAt.startsWith("+")
     ? ""
@@ -64,11 +62,15 @@ export default function ChattingListItem({
           <div className="flex flex-col gap-0 lg:gap-1">
             <div>
               <span className="font-semibold text-lg lg:text-xl">
-                <span>{nickname}</span>
-                {groupInfo && (
-                  <span className="text-site-darkgray-02 ml-3">
-                    {groupInfo.totalMembers}
-                  </span>
+                {isPrivateChat ? (
+                  <span>@{userInfo?.nickname}</span>
+                ) : (
+                  <>
+                    <span>{groupInfo?.groupName}</span>
+                    <span className="text-site-darkgray-02 ml-3">
+                      {groupInfo?.totalMembers}
+                    </span>
+                  </>
                 )}
               </span>
             </div>

--- a/src/app/(with-main-header)/friends/add/FriendRequestButton.tsx
+++ b/src/app/(with-main-header)/friends/add/FriendRequestButton.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { revalidatePathAction } from "@/actions";
+import { revalidateTagAction } from "@/actions";
 import { friendApi } from "@/api/friend/friend";
+import { userApi } from "@/api/user/user";
 import Button from "@/components/common/Button";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function FriendRequestButton({
   user,
 }: {
   user: userType | PartyParticipantType;
 }) {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isRequestFriend, setIsRequestFriend] = useState(
     user.status && user.status !== "NOT_FRIEND",
   );
@@ -23,7 +25,7 @@ export default function FriendRequestButton({
     if (res?.data) {
       setFriendId(res.data.friendId);
       setStatus("PENDING");
-      revalidatePathAction(`user-update-${user.userId}`);
+      revalidateTagAction(`user-update-${user.userId}`);
     }
   };
 
@@ -35,15 +37,27 @@ export default function FriendRequestButton({
     if (res?.status === "성공") {
       setFriendId(null);
       setStatus("NOT_FRIEND");
-      revalidatePathAction(`user-update-${user.userId}`);
+      revalidateTagAction(`user-update-${user.userId}`);
     }
   };
+
+  useEffect(() => {
+    const fetchCurrentUser = async () => {
+      const isLoggedIn = await userApi.checkIsLoggedIn();
+      if (isLoggedIn?.status === "성공") {
+        setIsLoggedIn(isLoggedIn.data);
+      }
+    };
+
+    fetchCurrentUser();
+  }, []);
+
   return isRequestFriend ? (
     <Button onClick={deleteFriend}>
       {status === "FRIEND" || status === "ACCEPTED" ? "삭제" : "요청취소"}
     </Button>
   ) : (
-    <Button onClick={requestFriend} disabled={status === null}>
+    <Button onClick={requestFriend} disabled={!isLoggedIn && status === null}>
       친구요청
     </Button>
   );

--- a/src/app/(with-main-header)/mypage/MyProfile.tsx
+++ b/src/app/(with-main-header)/mypage/MyProfile.tsx
@@ -12,7 +12,7 @@ export default async function MyProfile() {
   return (
     <section className="flex flex-col min-w-full lg:min-w-100 gap-2.5 lg:gap-7 px-2.5">
       <p className="font-bitbitv2 text-2xl lg:text-[28px]">
-        {user.data.nickname}
+        @{user.data.nickname}
       </p>
       <div className="flex items-center lg:items-end gap-13">
         <Avatar

--- a/src/app/(with-main-header)/users/[id]/Jandy.tsx
+++ b/src/app/(with-main-header)/users/[id]/Jandy.tsx
@@ -6,6 +6,9 @@ import {
 import { twMerge } from "tailwind-merge";
 
 export default function Jandy({ studyTime }: { studyTime: studyTimeType }) {
+  const hour = Number(studyTime.studyTime.split(":")[0]);
+  const minute = Number(studyTime.studyTime.split(":")[1]);
+  const second = Number(studyTime.studyTime.split(":")[2]);
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -13,10 +16,11 @@ export default function Jandy({ studyTime }: { studyTime: studyTimeType }) {
           key={studyTime.studyDate}
           className={twMerge(
             "w-full h-9 bg-white/50",
-            Number(studyTime.studyTime.split(":")[2]) >= 1 && "bg-[#FBF3B9]",
-            Number(studyTime.studyTime.split(":")[0]) >= 2 && "bg-[#FFDCCC]",
-            Number(studyTime.studyTime.split(":")[0]) >= 4 && "bg-[#FDB7EA]",
-            Number(studyTime.studyTime.split(":")[0]) >= 6 && "bg-[#B7B1F2",
+            (hour >= 1 || minute >= 1 || (minute > 0 && second >= 1)) &&
+              "bg-[#FBF3B9]",
+            hour >= 2 && "bg-[#FFDCCC]",
+            hour >= 4 && "bg-[#FDB7EA]",
+            hour >= 6 && "bg-[#B7B1F2",
           )}
         ></div>
       </TooltipTrigger>

--- a/src/app/(with-main-header)/users/[id]/UserProfile.tsx
+++ b/src/app/(with-main-header)/users/[id]/UserProfile.tsx
@@ -19,7 +19,7 @@ export default async function UserProfile({ userId }: UserProfileProps) {
   return (
     <section className="flex flex-col min-w-full lg:min-w-92 gap-2.5 lg:gap-7 px-2.5">
       <p className="font-bitbitv2 text-2xl lg:text-[28px]">
-        {user.data.nickname}
+        @{user.data.nickname}
       </p>
       <div className="flex items-center lg:items-end gap-13">
         <Avatar

--- a/src/components/common/NotificationList.tsx
+++ b/src/components/common/NotificationList.tsx
@@ -96,7 +96,9 @@ export default function NotificationList({
             >
               <p className="text-base my-3 text-black line-clamp-2 overflow-hidden">
                 {notification.type !== "CONFIRM" && (
-                  <span className="font-semibold">{notification.nickname}</span>
+                  <span className="font-semibold">
+                    @{notification.nickname}
+                  </span>
                 )}
                 <span className="font-normal">
                   {getNotificationMessage(notification)}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->

## ✨ 반영 브랜치

`feat/add-signup-toast` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->

## 📝 설명

<!-- 상세 task 변경사항 체크리스트로 기술 -->

## ✅ 변경 사항

- [x] 로그인 - 로그인 성공 토스트 추가
- [x] 회원가입 - `alert`를 모두 토스트로 변경 및 회원가입 성공 토스트 추가
- [x] 마이페이지 - 잔디 색상 버그 수정
- [x] 유저 프로필 페이지 - 로그인한 경우에 친구 요청 버튼이 비활성화 되는 버그 수정
- [x] 유저 닉네임 앞에 `@`가 빠진 부분 추가
- [x] 자동 로그인 코드 추가 삭제

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->

## 💬 PR 포인트 & 질문사항

- PR 좀 봐주세요~~
- 어떻게 생각하시나요?

## 📷 변경사항 스크린샷

<!-- 필수는 아니지만, 변경사항을 사진으로 공유하시면 좋아요! -->

- 변화된 부분을 올려주시면 좋아요 ✔

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->

## 📢 이슈 정보

[이슈 번호/정보](이슈 url)
